### PR TITLE
Update varchar columns in parameters, regions, and events tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+### Changed
+- Updated parameters.name, parameters.title, regions.title, and events.attributes column types.
+  [GEOD-1361](https://opensource.ncsa.illinois.edu/jira/browse/GEOD-1361)
+
 ## [3.0.2] - 2020-08-27
 
 ### Fixed

--- a/geostreams.sql
+++ b/geostreams.sql
@@ -436,7 +436,7 @@ CREATE TABLE events (
       gid integer default nextval('geoindex_gid_seq'::regclass) PRIMARY KEY,
       userid integer REFERENCES users (gid),
       sources varchar(50),
-      attributes varchar(200),
+      attributes text,
       geocode varchar(2000),
       since varchar(50),
       until varchar(50),
@@ -469,7 +469,7 @@ create cast (text as DOUBLE PRECISION) with function cast_to_double(text);
 --
 CREATE TABLE regions(
       id varchar(10) PRIMARY KEY,
-      title varchar(50),
+      title varchar(200),
       boundary geography,
       center_coordinate geography
 );
@@ -497,8 +497,8 @@ CREATE TABLE parameters
     gid integer default nextval('geoindex_gid_seq' :: regclass) not null
     constraint parameters_pkey
     primary key,
-    name         varchar(50) not null,
-    title        varchar(100),
+    name         varchar(200) not null,
+    title        varchar(200),
     unit         varchar(20),
     search_view  boolean default true,
     explore_view boolean default true,


### PR DESCRIPTION
The following `varchar` columns needed to be updated to allow longer strings:
- events.attributes
- parameters.name
- parameters.title
- regions.title

Databases across projects are updated manually with the following query. You can use it to update your local databases.
`ALTER TABLE <table-name> ALTER COLUMN <column-name> TYPE <new-type>`.

This PR is mostly for your information and shows the changes in the database schema.