### PR TITLE
[GEOD-1356] Support for nested parameters (i.e. zooplankton data) in trends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## UNRELEASED 
+### Added
+- Support for nested parameters in cached trends endpoints [GEOD-1356](https://opensource.ncsa.illinois.edu/jira/browse/GEOD-1356)
+### Changed
+
 
 ## 3.1.0 - 2020-12-14
 

--- a/app/controllers/CacheController.scala
+++ b/app/controllers/CacheController.scala
@@ -667,7 +667,7 @@ class CacheController @Inject() (val silhouette: Silhouette[TokenEnv], sensorDB:
       val max_end_time = new DateTime(sensor.max_end_time)
       var first_year = max_end_time.getYear()
       var last_average = 0.0
-      val allbins = cacheDB.getCachedBinStatsBySeason(sensor, season, None, None, parameter, false)
+      val allbins = cacheDB.getCachedBinStatsBySeason(sensor, season, None, None, parameter, false, true)
       var total_count = 0.0
       var total_sum = 0.0
       var last10_count = 0.0

--- a/app/db/Cache.scala
+++ b/app/db/Cache.scala
@@ -32,7 +32,7 @@ trait Cache {
 
   def getCachedBinStatsByYear(sensor: SensorModel, since: Option[String], until: Option[String], parameter: String, total: Boolean): List[(Int, Int, Double, Double, Timestamp, Timestamp)]
 
-  def getCachedBinStatsBySeason(sensor: SensorModel, season: Option[String], since: Option[String], until: Option[String], parameter: String, total: Boolean): List[(Int, String, Int, Double, Double, Timestamp, Timestamp)]
+  def getCachedBinStatsBySeason(sensor: SensorModel, season: Option[String], since: Option[String], until: Option[String], parameter: String, total: Boolean, sumNested: Boolean = false): List[(Int, String, Int, Double, Double, Timestamp, Timestamp)]
 
   def getCachedArrayBinStatsBySeason(sensor: SensorModel, season: Option[String], since: Option[String], until: Option[String], parameter: String, total: Boolean): List[(Int, String, Int, Map[String, Double], Timestamp, Timestamp)]
 

--- a/app/db/Parameters.scala
+++ b/app/db/Parameters.scala
@@ -26,4 +26,6 @@ trait Parameters {
   def addMapping(mapping: CategoryParameterMapping): CategoryParameterMapping
   def getMappingByParameterId(parameterId: Int): List[CategoryParameterMapping]
 
+  def isParameterNested(name: String): Boolean
+
 }

--- a/app/db/postgres/PostgresParameters.scala
+++ b/app/db/postgres/PostgresParameters.scala
@@ -365,4 +365,9 @@ class PostgresParameters @Inject() (db: Database) extends Parameters {
     mappings.toList
   }
 
+  override def isParameterNested(name: String): Boolean = {
+    val nested_parameters = getParametersByDetailType("stacked_bar")
+    nested_parameters.exists(_.name == name)
+  }
+
 }


### PR DESCRIPTION
## Info
- This PR adds support for getting trends of nested parameters through the same endpoint (/api/cache/trends) as regular parameters. 
- Added a boolean parameter `sumNested` to getCachedBinStatsBySeason which controls whether to sum the values of the nested parameters or treat it normally. 

## How to test?
- Run the [Geodashboard PR-34](https://github.com/geostreams/geodashboard/pull/34) with the geostreams url pointed to the local instance with zooplankton and phytoplankton data. 
- Run glm instance and select 'Zooplankton Density Total' parameter in http://localhost:8080/trendsstations.
- It should display the trends as below.
<img width="1792" alt="Screen Shot 2021-01-20 at 6 10 32 AM" src="https://user-images.githubusercontent.com/25838464/105174192-cc82c700-5ae7-11eb-8273-f5b6d11ef3ca.png">
