### PR TITLE
Fixes getCachedArrayBinStats SQL Query

### DIFF
--- a/app/db/postgres/PostgresCache.scala
+++ b/app/db/postgres/PostgresCache.scala
@@ -1594,7 +1594,7 @@ class PostgresCache @Inject() (db: Database, sensors: Sensors, parametersDB: Par
           "min(start_time) as start_time, max(end_time) as end_time " +
           "FROM ( SELECT yyyy, mm, dd,AVG(average) as average, max(datapoint_count) as datapoint_count, sum(sum), " +
           "	  			min(start_time) as start_time, max(end_time) as end_time, " +
-          "	  		trim(leading ? from parameter) as parameter " +
+          "	  		replace(parameter, ?, '') as parameter  " +
           "	  	FROM bins_day  " +
           "	  	WHERE sensor_id = ?  " +
           "		AND parameter like ?  " +


### PR DESCRIPTION
The trim function previously used removes extra characters from the string resulting in the value name being wrong. The purpose of this is to basically get the attribute name in nested datapoints since it is stored as <parameter_name>/<attribute_name> and we need just the attribute name. The replace function works as needed to remove the prefix string only and not extra characters. 